### PR TITLE
FIX: Remove extra header padding

### DIFF
--- a/desktop/desktop.scss
+++ b/desktop/desktop.scss
@@ -93,7 +93,3 @@
     height: auto;
   }
 }
-
-#main-outlet {
-  padding-top: 120px;
-}


### PR DESCRIPTION
Too much padding is the result of the header change in Discourse core (`fixed` to `sticky`, see: https://github.com/discourse/discourse/pull/10781)

Before / after / try.discourse.org for comparison

<img width="266" alt="Screen Shot 2021-05-04 at 13 35 55" src="https://user-images.githubusercontent.com/66961/116998145-116ceb00-acde-11eb-9f8e-f9459044ac31.png"> <img width="266" alt="Screen Shot 2021-05-04 at 13 35 50" src="https://user-images.githubusercontent.com/66961/116998161-15990880-acde-11eb-98b2-d9db8971c256.png"> <img width="266" alt="Screen Shot 2021-05-04 at 13 40 37" src="https://user-images.githubusercontent.com/66961/116998341-5b55d100-acde-11eb-8b85-a1b3c05cf638.png">
