### PR TITLE
FIX: Remove curved button styling from active nav links

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -39,10 +39,6 @@
   margin-right: 5px;
 }
 
-.nav-pills > li a.active {
-  box-shadow: 0px 3px  0px $danger;
-}
-
 .unseen-topic {
   font-size: 1.1em;
 }


### PR DESCRIPTION
This PR cleans up the styling for active navigation links.
- Removed the unnecessary curved button style applied to active links.
- Kept the default underline styling via the :after pseudo-element on the <a> tag.

**Before**

<img width="498" height="408" alt="image" src="https://github.com/user-attachments/assets/3e6889c5-39a3-42f5-b0a4-49c0b37b139c" />

**After**
<img width="296" height="63" alt="image" src="https://github.com/user-attachments/assets/96f1972f-f6c6-4eb5-be3b-4467eac5e6e0" />
